### PR TITLE
added PEP 561 support for cmdkit

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include LICENSE
+include cmdkit/py.typed

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     keywords         = 'command-line utility toolkit',
     url              = 'https://cmdkit.readthedocs.io',
     packages         = find_packages(),
+    include_package_data = True,
     long_description = long_description,
     long_description_content_type = 'text/x-rst',
     classifiers      = ['Development Status :: 5 - Production/Stable',
@@ -59,7 +60,7 @@ setup(
                         'License :: OSI Approved :: Apache Software License', ],
     entry_points     = {'console_scripts': []},
     install_requires = DEPENDENCIES,
-    extras_require  = {
+    extras_require   = {
         'toml': ['toml>=0.10.1', ],
         'yaml': ['pyyaml>=5.3.1', ],
     },


### PR DESCRIPTION
To support proper type annotation checking with mypy for dependent projects.

https://www.python.org/dev/peps/pep-0561/