### PR TITLE
Capability to Override Version & Help 

### DIFF
--- a/cmdkit/app.py
+++ b/cmdkit/app.py
@@ -68,11 +68,11 @@ class Application(abc.ABC):
     log_exception: Callable[[str], None] = log.exception
 
     @classmethod
-    def log_help(cls, message: str) -> None:
+    def handle_help(cls, message: str) -> None:
         print(message)
 
     @classmethod
-    def log_version(cls, *args) -> None:
+    def handle_version(cls, *args) -> None:
         print(*args)
 
     def __init__(self, **parameters) -> None:
@@ -115,11 +115,11 @@ class Application(abc.ABC):
             return exit_status.success
 
         except cli.HelpOption as help_text:
-            cls.log_help(help_text)
+            cls.handle_help(help_text)
             return exit_status.success
 
         except cli.VersionOption as version:
-            cls.log_version(*version.args)
+            cls.handle_version(*version.args)
             return exit_status.success
 
         except cli.ArgumentError as error:

--- a/cmdkit/app.py
+++ b/cmdkit/app.py
@@ -153,7 +153,7 @@ class ApplicationGroup(Application):
     """
 
     interface: cli.Interface = None
-    commands: Dict[str, Application] = None
+    commands: Dict[str, Type[Application]] = None
     command: str = None
 
     ALLOW_PARSE: bool = False

--- a/cmdkit/app.py
+++ b/cmdkit/app.py
@@ -67,6 +67,14 @@ class Application(abc.ABC):
     log_critical: Callable[[str], None] = log.critical
     log_exception: Callable[[str], None] = log.exception
 
+    @classmethod
+    def log_help(cls, message: str) -> None:
+        print(message)
+
+    @classmethod
+    def log_version(cls, *args) -> None:
+        print(*args)
+
     def __init__(self, **parameters) -> None:
         """Direct initialization sets `parameters`."""
         for name, value in parameters.items():
@@ -107,11 +115,11 @@ class Application(abc.ABC):
             return exit_status.success
 
         except cli.HelpOption as help_text:
-            print(help_text)
+            cls.log_help(help_text)
             return exit_status.success
 
         except cli.VersionOption as version:
-            print(*version.args)
+            cls.log_version(*version.args)
             return exit_status.success
 
         except cli.ArgumentError as error:


### PR DESCRIPTION
Provide the capability to override the default behavior of VersionOption and HelpOption.

This is needed in cases where the derived class desires to override (or monkey patch the base class) the default printing behavior of these try except cases.

This pull request also includes corrected type annotations for ApplicationGroup.commands.